### PR TITLE
use proposal threshold where appropriate

### DIFF
--- a/docs/federation-state-machine.md
+++ b/docs/federation-state-machine.md
@@ -24,7 +24,6 @@ Leader                          Follower A                    Follower B
   |          |                     |                             |
   |     apply() locally       apply() locally              apply() locally
   |     - verify anchoring    - verify anchoring           - verify anchoring
-  |     - write to DB         - write to DB                - write to DB
   |     - update state        - update state               - update state
 ```
 
@@ -34,7 +33,8 @@ Leader                          Follower A                    Follower B
 pub struct StateMachineData {
     pub last_applied_log: Option<LogId<TypeConfig>>,
     pub last_membership: StoredMembership<TypeConfig>,
-    pub peers: HashMap<String, Peer>,
+    pub active_peers: HashMap<String, Peer>,
+    pub inactive_peers: HashMap<String, Peer>,
     pub pending_addition_proposals: HashMap<String, PeerAdditionProposal>,
     pub completed_addition_proposals: Vec<Vec<PeerAdditionProposal>>,
     pub pending_removal_proposals: HashMap<String, PeerRemovalProposal>,
@@ -46,7 +46,7 @@ pub struct StateMachineData {
 
 ### Peers
 
-The `peers` HashMap is the peer set, keyed by `peer_prefix`. These are the peers trusted across all federation members.
+Active and inactive peers are stored in separate HashMaps, both keyed by `peer_prefix`. Active peers are the trusted peer set. Inactive peers are deactivated peers preserved for audit trail — when a peer is removed, it moves from `active_peers` to `inactive_peers` rather than being deleted.
 
 ### Member KELs
 
@@ -80,14 +80,14 @@ Votes are stored separately in a `votes` HashMap keyed by SAID, not embedded in 
 
 The `StateMachineData::apply()` method is a pure, synchronous function that updates in-memory state. It handles:
 
-- **AddPeer**: Inserts peer into `peers` HashMap
-- **RemovePeer**: Removes peer from `peers` HashMap
+- **AddPeer**: Inserts peer into `active_peers` HashMap
+- **RemovePeer**: Moves peer from `active_peers` to `inactive_peers` (must be deactivated; rejects active peers)
 - **SubmitAdditionProposal**: v0 creates an empty proposal checking for duplicate peers/proposals; v1 withdraws (only before any votes are cast)
 - **SubmitRemovalProposal**: v0 creates a removal proposal checking the peer exists; v1 withdraws (only before any votes are cast)
-- **VotePeer**: Records vote, checks threshold.
-  - If theshold met:
+- **VotePeer**: Records vote, checks threshold (from the proposal, not config).
+  - If threshold met:
     - Additions: returns the approved proposal — the leader handler then creates the peer, anchors it, and submits `AddPeer`
-    - Removals: auto-removes peer from peer set.
+    - Removals: returns the approved proposal — the leader handler then deactivates the peer, anchors it, and submits `RemovePeer`
     - Both: moves proposal to completed.
 - **SubmitKeyEvents**: Merges events into `member_kels` for the given prefix. Uses `Kel::from_events()` for the first submission (empty KEL) and `Kel::merge()` for subsequent submissions
 
@@ -99,13 +99,21 @@ The `StateMachineStore` implements OpenRaft's `RaftStateMachine` trait. Its asyn
 
 Before applying an `AddPeer` entry from the Raft log:
 
-1. **Vote threshold**: Count verified voters — each vote must pass SAID integrity (`verify_said()`) and be anchored in the voter's KEL (`verify_member_anchoring`). Reject if verified voters < threshold.
-2. **KEL anchoring**: Verify the peer's SAID is anchored in a federation member's KEL (`verify_member_anchoring`). This proves a trusted member authorized this peer.
-3. **DB write**: Write the peer to our local PostgreSQL database via `upsert_peer_to_db`.
+1. **Proposal threshold**: Find the completed addition proposal for this peer and extract its stored threshold. Reject if no completed proposal exists. Enforce the minimum threshold floor (`compute_approval_threshold(0)`, currently 3) — see [Threshold Verification](#threshold-verification).
+2. **Vote threshold**: Count verified voters — each vote must pass SAID integrity (`verify_said()`) and be anchored in the voter's KEL (`verify_member_anchoring`). Reject if verified voters < proposal threshold.
+3. **KEL anchoring**: Verify the peer's SAID is anchored in a federation member's KEL (`verify_member_anchoring`). This proves a trusted member authorized this peer.
 
 Note: Self-anchoring (anchoring the peer's SAID in our own KEL) does not happen in `apply()`. It happens in the leader's HTTP handler before submitting the `AddPeer` request.
 
 If threshold or anchoring verification fails, the entry is **skipped** (not applied to state). This means a rogue leader cannot add unauthorized peers — followers independently verify vote threshold and anchoring, rejecting unverified entries.
+
+### RemovePeer Verification
+
+Before applying a `RemovePeer` entry from the Raft log:
+
+1. **Proposal threshold**: Find the completed removal proposal for this peer and extract its stored threshold. Reject if no completed proposal exists. Enforce the minimum threshold floor.
+2. **Vote threshold**: Count verified voters from the completed removal proposal. Reject if verified voters < proposal threshold.
+3. **KEL anchoring**: Verify the deactivated peer's SAID is anchored in the authorizing member's KEL.
 
 ### VotePeer Verification
 
@@ -120,7 +128,7 @@ Before applying a vote:
 
 Before applying a proposal:
 
-1. **Threshold check**: Verify the proposal's `threshold` field matches the current `approval_threshold()` — ensures proposer and federation agree on membership size
+1. **Threshold floor**: Verify the proposal's `threshold` field meets the minimum floor (`compute_approval_threshold(0)`) — see [Threshold Verification](#threshold-verification). The exact-match check against current config happens in the leader's HTTP handler, not here.
 2. **Proposal anchoring**: Verify the proposal's SAID is anchored in the proposer's KEL
 
 ### SubmitKeyEvents Verification
@@ -133,12 +141,13 @@ Before applying key events:
 
 ### Approved Proposal Side Effects
 
-When a `VotePeer` triggers addition approval (threshold met), the state machine returns `VoteRecorded { approved: true, proposal: Some(...) }`. The leader's HTTP handler then creates the Peer record, anchors the peer's SAID in its own KEL, writes the peer to the local database, and submits a separate `AddPeer` request to Raft. These side effects happen in the handler, not in the state machine's `apply()`.
+When a `VotePeer` triggers addition approval (threshold met), the state machine returns `VoteRecorded { approved: true, proposal: Some(...) }`. The leader's HTTP handler then creates the Peer record, anchors the peer's SAID in its own KEL, and submits a separate `AddPeer` request to Raft. These side effects happen in the handler, not in the state machine's `apply()`.
 
-When a `VotePeer` triggers removal approval, the async layer:
+When a `VotePeer` triggers removal approval, the state machine returns `RemovalApproved` with the proposal. The leader's HTTP handler then:
 
-1. Deactivates the peer in the local database
-2. Anchors the deactivated peer's SAID in our KEL
+1. Deactivates the peer (sets `active = false`, increments version)
+2. Anchors the deactivated peer's SAID in its own KEL
+3. Submits a separate `RemovePeer` request to Raft
 
 ## Defense in Depth
 
@@ -179,7 +188,7 @@ The peer set flows to multiple consumers:
 
 The state machine supports snapshotting for efficient Raft log compaction:
 
-- **Snapshot**: Serializes `peers`, `pending_addition_proposals`, `completed_addition_proposals`, `pending_removal_proposals`, `completed_removal_proposals`, `votes`, and `member_kels` to JSON
+- **Snapshot**: Serializes `active_peers`, `inactive_peers`, `pending_addition_proposals`, `completed_addition_proposals`, `pending_removal_proposals`, `completed_removal_proposals`, `votes`, and `member_kels` to JSON
 - **Restore**: Deserializes and verifies all proposal chains and member KELs before accepting. Proposals with invalid chains are dropped during restore. Member KELs are verified with `kel.verify()` before restoring.
 
 ## KEL Sync Loop
@@ -200,6 +209,22 @@ The voting threshold for peer approval scales with federation size:
 
 The minimum threshold of 3 prevents trivial collusion — even in the smallest viable federation (3 members), all members must agree.
 
+## Threshold Verification
+
+The approval threshold is stored on each proposal at creation time. Threshold verification is split across two layers:
+
+### Leader Handler (Exact Match)
+
+When a proposal is submitted via the HTTP API, the leader handler verifies `proposal.threshold == approval_threshold()` — rejecting proposals where the threshold doesn't match the current federation config. This runs only at real submission time, never during Raft log replay.
+
+### Outer `apply()` (Floor Check)
+
+When replaying Raft log entries (e.g., after a registry restart), the outer `apply()` only enforces a minimum threshold floor (`compute_approval_threshold(0)`, currently 3). It does **not** check against the current config because the config may have changed since the entry was originally committed — a federation that grew from 3 to 10 members would have a different `approval_threshold()` than when earlier proposals were accepted. An exact-match check during replay would incorrectly reject legitimate historical entries.
+
+### Why Both Layers Are Needed
+
+The exact-match check in the leader handler prevents a proposer from submitting a proposal with an artificially low threshold (e.g., threshold 3 in a 10-member federation where the correct threshold is 4). The floor check in `apply()` is defense-in-depth: if a forged proposal with a below-minimum threshold somehow enters the Raft log (e.g., through a bug or exploit), followers will reject it. Together with the floor check on `AddPeer`/`RemovePeer` verification, this ensures that no peer change can ever be approved with fewer than 3 verified votes, regardless of how the entry entered the log.
+
 ## Rogue Leader Attack
 
 A compromised leader could attempt to:
@@ -207,6 +232,7 @@ A compromised leader could attempt to:
 1. **Add unauthorized peers via `AddPeer`**: Blocked by follower-side KEL anchoring verification
 2. **Fabricate votes**: Blocked by vote SAID verification and KEL anchoring checks
 3. **Tamper with proposal history**: Blocked by proposal chain verification
-4. **Skip the voting process entirely**: Blocked by vote verification in `apply()` -- followers check that a completed proposal with sufficient unique voter prefixes exists
+4. **Skip the voting process entirely**: Blocked by vote verification in `apply()` — followers check that a completed proposal with sufficient unique voter prefixes exists
+5. **Forge a low-threshold proposal**: If three members collude and one becomes leader, they could craft a proposal with `threshold: 3` in a larger federation (e.g., 10 members, correct threshold 4). The leader handler's exact-match check rejects this at submission time. Even if the forged proposal enters the log, the floor check ensures followers never accept fewer than 3 verified votes. In the worst case — three colluding members successfully add a rogue peer — the resolution is straightforward: legitimate operators vote to remove the rogue peer via the standard removal proposal process.
 
 The key insight is that the Raft log is just a proposal mechanism. Followers independently verify every entry and reject anything that doesn't meet the verification criteria.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -211,7 +211,7 @@ kels-registry-admin peer vote --proposal-id EProposal456... --approve
 # Peer has been removed from the peer set.
 ```
 
-After approval, the peer is removed from the Raft state machine and deactivated in the database. The peer can be re-added later via a new addition proposal.
+After approval, the peer is deactivated and moved from active to inactive in the Raft state machine. The peer can be re-added later via a new addition proposal.
 
 ## Security Considerations
 
@@ -260,6 +260,15 @@ If a federation member is compromised:
 ### Approval Requirements
 
 Peer changes require the approval threshold described above — minimum 3 votes, scaling to ceil(n/3) at scale. A single compromised registry cannot unilaterally modify the peer set.
+
+#### Threshold Verification
+
+The approval threshold is stored on each proposal at creation time. Verification is split across two layers:
+
+- **Leader handler** (exact match): At proposal submission time, the leader rejects proposals where `threshold != approval_threshold()`. This prevents a proposer from submitting a low threshold in a large federation.
+- **Raft `apply()`** (floor check): During log replay and replication, followers enforce only a minimum threshold floor (`compute_approval_threshold(0)`, currently 3). The exact-match check is deliberately not repeated here because the config may have changed since the entry was committed — a federation that grew from 3 to 10 members would incorrectly reject legitimate historical proposals from when the threshold was 3.
+
+This split ensures that no peer change can be approved with fewer than 3 verified votes, while remaining safe across federation growth and Raft log replay. See [federation-state-machine.md](federation-state-machine.md#threshold-verification) for details.
 
 ### Split-Brain Protection
 

--- a/services/kels-registry/src/federation/state_machine.rs
+++ b/services/kels-registry/src/federation/state_machine.rs
@@ -873,6 +873,21 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
                             }
                         };
 
+                        // Defense-in-depth: enforce minimum threshold floor (see docs/federation.md)
+                        let min_threshold = FederationConfig::compute_approval_threshold(0);
+                        if threshold < min_threshold {
+                            warn!(
+                                peer_prefix = %peer.peer_prefix,
+                                threshold = threshold,
+                                min_threshold = min_threshold,
+                                "Proposal threshold below minimum - rejecting"
+                            );
+                            if let Some(r) = responder {
+                                r.send(FederationResponse::Ok);
+                            }
+                            continue;
+                        }
+
                         if verified_voters.len() < threshold {
                             warn!(
                                 peer_prefix = %peer.peer_prefix,
@@ -956,6 +971,21 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
                                 continue;
                             }
                         };
+
+                        // Defense-in-depth: enforce minimum threshold floor (see docs/federation.md)
+                        let min_threshold = FederationConfig::compute_approval_threshold(0);
+                        if threshold < min_threshold {
+                            warn!(
+                                peer_prefix = %peer.peer_prefix,
+                                threshold = threshold,
+                                min_threshold = min_threshold,
+                                "Removal proposal threshold below minimum - rejecting"
+                            );
+                            if let Some(r) = responder {
+                                r.send(FederationResponse::Ok);
+                            }
+                            continue;
+                        }
 
                         if verified_voters.len() < threshold {
                             warn!(
@@ -1078,20 +1108,23 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
                         continue;
                     }
 
-                    // Verify addition proposal anchoring
+                    // Verify addition proposal threshold floor and anchoring
                     if let FederationRequest::SubmitAdditionProposal(ref prop) = request {
-                        if prop.threshold != self.config.approval_threshold() {
+                        // Exact-match against current config is in the leader handler;
+                        // here we only enforce the floor so replayed entries from smaller
+                        // federations are not rejected after config growth.
+                        let min_threshold = FederationConfig::compute_approval_threshold(0);
+                        if prop.threshold < min_threshold {
                             warn!(
                                 proposer = %prop.proposer,
                                 proposal_threshold = prop.threshold,
-                                current_threshold = self.config.approval_threshold(),
-                                "Addition proposal threshold mismatch - rejecting"
+                                min_threshold = min_threshold,
+                                "Addition proposal threshold below minimum - rejecting"
                             );
                             if let Some(r) = responder {
                                 r.send(FederationResponse::NotAuthorized(format!(
-                                    "Proposal threshold {} doesn't match current threshold {}",
-                                    prop.threshold,
-                                    self.config.approval_threshold()
+                                    "Proposal threshold {} below minimum {}",
+                                    prop.threshold, min_threshold
                                 )));
                             }
                             continue;
@@ -1106,21 +1139,20 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
                         }
                     }
 
-                    // Verify removal proposal anchoring
+                    // Verify removal proposal threshold floor and anchoring
                     if let FederationRequest::SubmitRemovalProposal(ref prop) = request {
-                        // Verify threshold matches current
-                        if prop.threshold != self.config.approval_threshold() {
+                        let min_threshold = FederationConfig::compute_approval_threshold(0);
+                        if prop.threshold < min_threshold {
                             warn!(
                                 proposer = %prop.proposer,
                                 proposal_threshold = prop.threshold,
-                                current_threshold = self.config.approval_threshold(),
-                                "Removal proposal threshold mismatch - rejecting"
+                                min_threshold = min_threshold,
+                                "Removal proposal threshold below minimum - rejecting"
                             );
                             if let Some(r) = responder {
                                 r.send(FederationResponse::NotAuthorized(format!(
-                                    "Proposal threshold {} doesn't match current threshold {}",
-                                    prop.threshold,
-                                    self.config.approval_threshold()
+                                    "Proposal threshold {} below minimum {}",
+                                    prop.threshold, min_threshold
                                 )));
                             }
                             continue;

--- a/services/kels-registry/src/handlers.rs
+++ b/services/kels-registry/src/handlers.rs
@@ -720,8 +720,9 @@ pub async fn admin_get_proposal(
 ///
 /// Full verification before Raft submission:
 /// 1. Proposer is a federation member
-/// 2. Build and verify the full proposal chain (AdditionHistory)
-/// 3. Verify each record's SAID is anchored in proposer's KEL
+/// 2. Threshold matches current config (new proposals only)
+/// 3. Build and verify the full proposal chain (AdditionHistory)
+/// 4. Verify each record's SAID is anchored in proposer's KEL
 pub async fn admin_submit_addition_proposal(
     State(state): State<Arc<FederationState>>,
     Json(proposal): Json<PeerAdditionProposal>,
@@ -734,7 +735,17 @@ pub async fn admin_submit_addition_proposal(
         )));
     }
 
-    // 2. Build and verify the full proposal chain
+    // 2. Verify threshold matches current config (only enforced at submission time,
+    //    not during Raft log replay where config may have changed)
+    if proposal.previous.is_none() && proposal.threshold != state.node.approval_threshold() {
+        return Err(ApiError::bad_request(format!(
+            "Proposal threshold {} doesn't match current threshold {}",
+            proposal.threshold,
+            state.node.approval_threshold()
+        )));
+    }
+
+    // 3. Build and verify the full proposal chain
     let records = if proposal.previous.is_some() {
         // Withdrawal (v1): fetch existing v0 and build full chain
         let existing = state
@@ -759,7 +770,7 @@ pub async fn admin_submit_addition_proposal(
         .verify()
         .map_err(|e| ApiError::bad_request(format!("Proposal chain verification failed: {}", e)))?;
 
-    // 3. Verify each record's SAID is anchored in proposer's KEL
+    // 4. Verify each record's SAID is anchored in proposer's KEL
     ensure_own_kel_synced(&state).await;
     for record in &history.records {
         state
@@ -769,7 +780,7 @@ pub async fn admin_submit_addition_proposal(
             .map_err(|e| ApiError::unauthorized(format!("Anchoring verification failed: {}", e)))?;
     }
 
-    // 4. Submit to Raft
+    // 5. Submit to Raft
     let response = state
         .node
         .submit_addition_proposal(proposal)
@@ -842,7 +853,17 @@ pub async fn admin_submit_removal_proposal(
         )));
     }
 
-    // 2. Build and verify the full proposal chain
+    // 2. Verify threshold matches current config (only enforced at submission time,
+    //    not during Raft log replay where config may have changed)
+    if proposal.previous.is_none() && proposal.threshold != state.node.approval_threshold() {
+        return Err(ApiError::bad_request(format!(
+            "Proposal threshold {} doesn't match current threshold {}",
+            proposal.threshold,
+            state.node.approval_threshold()
+        )));
+    }
+
+    // 3. Build and verify the full proposal chain
     let records = if proposal.previous.is_some() {
         let existing = state
             .node
@@ -865,7 +886,7 @@ pub async fn admin_submit_removal_proposal(
         ApiError::bad_request(format!("Removal proposal chain verification failed: {}", e))
     })?;
 
-    // 3. Verify each record's SAID is anchored in proposer's KEL
+    // 4. Verify each record's SAID is anchored in proposer's KEL
     ensure_own_kel_synced(&state).await;
     for record in &history.records {
         state
@@ -875,7 +896,7 @@ pub async fn admin_submit_removal_proposal(
             .map_err(|e| ApiError::unauthorized(format!("Anchoring verification failed: {}", e)))?;
     }
 
-    // 4. Submit to Raft
+    // 5. Submit to Raft
     let response = state
         .node
         .submit_removal_proposal(proposal)


### PR DESCRIPTION
closes #34 

  - Removed threshold parameter from inner apply() — it no longer takes an external threshold                                                                                                                        
  - Inner apply() VotePeer: extracts threshold from the proposal itself, returns InternalError if the proposal isn't found (instead of silently falling back to config threshold)                                    
  - Inner apply() SubmitAdditionProposal/SubmitRemovalProposal: votes_needed now uses submitted.threshold instead of the passed-in parameter                                                                         
  - Outer apply() AddPeer verification: finds the completed proposal's threshold instead of using self.config.approval_threshold(); rejects if no completed proposal exists
  - Outer apply() RemovePeer verification: same pattern — uses proposal's stored threshold
  - Config threshold is now only checked at proposal submission time to ensure the proposal's threshold matches current config

## verification

```
make && make test-comprehensive
```